### PR TITLE
[feat] Add onnx runtime inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ Tracked pitch nearly identical as compared to `crepe`.
 ![](sample_2.png)
 
 ## TODO
-- [ ] Optimize inference performance
+- [ ] Add unit tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "torchcrepeV2"
-version = "0.1.3"
+version = "0.1.4"
 authors = [
   { name="Hao Hao Tan", email="helloharry66@gmail.com" },
 ]
@@ -15,10 +15,12 @@ classifiers = [
 dependencies = [
   'tensorflow',
   'torch',
-  'numpy',
   'crepe==0.0.12',
   'librosa==0.9.1',
-  'hmmlearn==0.2.7'
+  'hmmlearn==0.2.7',
+  'onnx',
+  'onnxruntime',
+  'numpy==1.19.5',
 ]
 
 [project.urls]

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,16 @@ try:
 except ImportError:
     from urllib import urlretrieve
 
+# download pytorch weight file
 base_url = 'https://github.com/gudgud96/torchcrepeV2/raw/master/torchcrepeV2/assets/model-full-crepe.pt'
 compressed_path = os.path.join('torchcrepeV2', 'model-full-crepe.pt')
 print('Downloading weight file model-full-crepe.pt')
+urlretrieve(base_url, compressed_path)
+
+# download onnx weight file
+base_url = 'https://github.com/gudgud96/torchcrepeV2/raw/master/torchcrepeV2/assets/crepe_model.onnx'
+compressed_path = os.path.join('torchcrepeV2', 'crepe_model.onnx')
+print('Downloading crepe_model.onnx')
 urlretrieve(base_url, compressed_path)
 
 with open("README.md", "r") as fh:
@@ -16,7 +23,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name='torchcrepeV2',  
-    version='0.1.2',
+    version='0.1.4',
     author="Hao Hao Tan",
     author_email="helloharry66@gmail.com",
     description="crepe, SOTA pitch tracking tool in PyTorch",
@@ -30,6 +37,6 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     package_data={
-        'torchcrepeV2': ['model-full-crepe.pt']
+        'torchcrepeV2': ['model-full-crepe.pt', 'crepe_model.onnx']
     },
  )

--- a/torchcrepeV2/core.py
+++ b/torchcrepeV2/core.py
@@ -1,11 +1,16 @@
 import torch
 import numpy as np
 from numpy.lib.stride_tricks import as_strided
+import onnxruntime
 from .crepe_model import TorchCrepe
 from .utils import to_viterbi_cents, to_local_average_cents
 import os
 
 class TorchCrepePredictor:
+    """
+    General TorchCrepe Predictor.
+    Empirical observation finds that CPU inference is slow, better to use ONNX runtime for CPU scenario.
+    """
     def __init__(self, device="cuda"):
         self.model = TorchCrepe()
         self.model.load_state_dict(torch.load(os.path.join(os.path.dirname(os.path.realpath(__file__)), "model-full-crepe.pt")))
@@ -78,6 +83,77 @@ class TorchCrepePredictor:
             cents = to_viterbi_cents(y.cpu().detach().numpy())
         else:
             cents = to_local_average_cents(y.cpu().detach().numpy())
+        
+        frequency = 10 * 2 ** (cents / 1200)
+        frequency[np.isnan(frequency)] = 0
+
+        return frequency
+
+
+class ONNXTorchCrepePredictor:
+    def __init__(self):
+        self.ort_session = onnxruntime.InferenceSession(os.path.join(os.path.dirname(os.path.realpath(__file__)), "crepe_model.onnx"))
+
+    def predict(self, audio, sr=16000, viterbi=True, center=True, step_size=10):
+        """
+        Perform pitch estimation on given audio
+        Parameters
+        ----------
+        audio : np.ndarray [shape=(N,) or (N, C)]
+            The audio samples. Multichannel audio will be downmixed.
+        sr : int
+            Sample rate of the audio samples. The audio will be resampled if
+            the sample rate is not 16 kHz, which is expected by the model.
+        model_capacity : 'tiny', 'small', 'medium', 'large', or 'full'
+            String specifying the model capacity; see the docstring of
+            :func:`~crepe.core.build_and_load_model`
+        viterbi : bool
+            Apply viterbi smoothing to the estimated pitch curve. False by default.
+        center : boolean
+            - If `True` (default), the signal `audio` is padded so that frame
+            `D[:, t]` is centered at `audio[t * hop_length]`.
+            - If `False`, then `D[:, t]` begins at `audio[t * hop_length]`
+        step_size : int
+            The step size in milliseconds for running pitch estimation.
+        verbose : int
+            Set the keras verbosity mode: 1 (default) will print out a progress bar
+            during prediction, 0 will suppress all non-error printouts.
+        Returns
+        -------
+        A 4-tuple consisting of:
+            time: np.ndarray [shape=(T,)]
+                The timestamps on which the pitch was estimated
+            frequency: np.ndarray [shape=(T,)]
+                The predicted pitch values in Hz
+            confidence: np.ndarray [shape=(T,)]
+                The confidence of voice activity, between 0 and 1
+            activation: np.ndarray [shape=(T, 360)]
+                The raw activation matrix
+        """
+        
+        # make 1024-sample frames of the audio with hop length of 10 milliseconds
+        if center:
+            x = np.pad(audio, 512, mode='constant', constant_values=0)
+        hop_length = int(sr * step_size / 1000)     # step_size = int(1000 * 160 / 16000)
+        n_frames = 1 + int((len(x) - 1024) / hop_length)
+        frames = as_strided(x, shape=(1024, n_frames),
+                            strides=(x.itemsize, hop_length * x.itemsize))
+        frames = frames.transpose().copy()
+
+        # normalize each frame -- this is expected by the model
+        frames -= np.mean(frames, axis=1)[:, np.newaxis]
+        frames /= np.std(frames, axis=1)[:, np.newaxis]
+
+        # onnx inference
+        ort_inputs = {self.ort_session.get_inputs()[0].name: frames.astype(np.float32)}
+        ort_outs = self.ort_session.run(None, ort_inputs)
+        
+        y = ort_outs[0]
+
+        if viterbi:
+            cents = to_viterbi_cents(y)
+        else:
+            cents = to_local_average_cents(y)
         
         frequency = 10 * 2 ** (cents / 1200)
         frequency[np.isnan(frequency)] = 0


### PR DESCRIPTION
Following https://github.com/gudgud96/torchcrepeV2/issues/1, add ONNX runtime support to speedup CPU inference (more catered for deploying to CPU production usage).

Tested on Macbook Pro 2019, using benchmark similar to - https://colab.research.google.com/drive/1rBC4bXSo3nujk6n9JeHJfErBaC8epxze?usp=sharing

```
Crepe: 8.851s
**ONNX: 4.09s**
TorchcrepeV2: 41.47s
Torchcrepe: 43.63s
```

Predicted result is the same as `crepe`.

![image](https://user-images.githubusercontent.com/13913915/199947401-214625b2-4991-4ec3-8ec4-ae7c1b715780.png)


